### PR TITLE
Use setup-gradle v4

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -21,14 +21,7 @@ jobs:
         with:
           java-version: 21
           distribution: temurin
-      - uses: gradle/actions/setup-gradle@v3
+      - uses: gradle/actions/setup-gradle@v4
 
       - name: Build with Gradle
         run: ./gradlew :app:assembleDebug
-
-  validate-wrapper:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v2


### PR DESCRIPTION
The new version of the GH Action also allows us to drop the Wrapper validation, as it is now handled by the `setup-gradle`